### PR TITLE
Correctly calculate video size for portrait videos

### DIFF
--- a/src/app/modules/webcam/webcam/webcam.component.ts
+++ b/src/app/modules/webcam/webcam/webcam.component.ts
@@ -168,11 +168,13 @@ export class WebcamComponent implements AfterViewInit, OnDestroy {
 
   public get videoWidth() {
     let videoRatio = this.activeVideoSettings ? this.activeVideoSettings.aspectRatio : (this.width / this.height);
+    if (videoRatio > 1) return Math.min(this.width, this.height / videoRatio);
     return Math.min(this.width, this.height * videoRatio);
   }
 
   public get videoHeight() {
     let videoRatio = this.activeVideoSettings ? this.activeVideoSettings.aspectRatio : (this.width / this.height);
+    if (videoRatio > 1) return Math.min(this.height, this.width * videoRatio);
     return Math.min(this.height, this.width / videoRatio);
   }
 


### PR DESCRIPTION
When the webcam container is rectangular, the video size is sometimes not calculated correctly for portrait mode. I'm not sure if my implementation covers all situations correctly. For my application it was working as expected, even when the device is rotated. In my case, the webcam width and height attributes are always set to screen size.